### PR TITLE
Fix for MTB 2.4.1 patch release

### DIFF
--- a/mtb-golioth-ce-manifest-fv2.xml
+++ b/mtb-golioth-ce-manifest-fv2.xml
@@ -9,11 +9,11 @@
     <br><br><a href="https://golioth.io/">Golioth</a> is a commercial IoT development platform built for scale.]]></description>
     <req_capabilities>psoc6 led switch std_crypto</req_capabilities>
     <versions>
-      <version flow_version="2.0" tools_min_version="3.0.0" tools_max_version="3.0.0" req_capabilities_per_version="bsp_gen4">
+      <version flow_version="2.0" tools_min_version="3.0.0" req_capabilities_per_version="bsp_gen4">
         <num>v2.0.1</num>
         <commit>v2.0.1</commit>
       </version>
-      <version flow_version="2.0" tools_min_version="2.4.0" tools_max_version="2.4.0" req_capabilities_per_version="bsp_gen3">
+      <version flow_version="2.0" tools_min_version="2.4.0" tools_max_version="2.4.1" req_capabilities_per_version="bsp_gen3">
         <num>v1.1.1</num>
         <commit>v1.1.1</commit>
       </version>


### PR DESCRIPTION
ModusToolbox 2.4.1 patch release will be out soon, and the changes are needed to ensure your MTB 2.4 content is visible in the patch release. 

I have removed the tools_max_version for the MTB 3.0 content because it will allow the content to be visible for all future releases of MTB 3.X. You can add the tools_max_version when the next major release i.e. MTB 4.0 is out. 

PS: You can proceed to merge these changes even prior to MTB 2.4.1 being out, it is not going to affect the content in the present tools in any way.